### PR TITLE
Only try to pick headers for a StatusError if headers are passed in

### DIFF
--- a/request.ts
+++ b/request.ts
@@ -39,8 +39,10 @@ export class StatusError extends TypedError {
 		headers: request.Response['headers'],
 	) {
 		super(message);
-		for (const header of headersOfInterest) {
-			this.headers[header] = headers[header];
+		if (headers != null) {
+			for (const header of headersOfInterest) {
+				this.headers[header] = headers[header];
+			}
 		}
 	}
 }


### PR DESCRIPTION
I think this is only a problem with poorly mocked request instances but adding the safety check doesn't cause a problem