### PR TITLE
Sub-class the `StatusError` for errors as pinejs-client-core expects

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
   "dependencies": {
     "@types/request": "^2.48.13",
     "lru-cache": "^11.2.1",
-    "pinejs-client-core": "^8.3.2",
-    "request": "^2.88.2",
-    "typed-error": "^3.2.2"
+    "pinejs-client-core": "^8.4.0",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@balena/lint": "^9.3.6",

--- a/request.ts
+++ b/request.ts
@@ -6,9 +6,11 @@ import type {
 	Resource,
 } from 'pinejs-client-core';
 
-import { PinejsClientCore } from 'pinejs-client-core';
+import {
+	PinejsClientCore,
+	StatusError as CoreStatusError,
+} from 'pinejs-client-core';
 import request from 'request';
-import { TypedError } from 'typed-error';
 
 const requestAsync = (
 	opts:
@@ -27,7 +29,7 @@ const requestAsync = (
 
 const headersOfInterest = ['retry-after'] as const;
 
-export class StatusError extends TypedError {
+export class StatusError extends CoreStatusError {
 	public headers: Pick<
 		request.Response['headers'],
 		(typeof headersOfInterest)[number]
@@ -35,10 +37,10 @@ export class StatusError extends TypedError {
 
 	constructor(
 		message: string,
-		public statusCode: number,
+		statusCode: number,
 		headers: request.Response['headers'],
 	) {
-		super(message);
+		super(message, statusCode);
 		if (headers != null) {
 			for (const header of headersOfInterest) {
 				this.headers[header] = headers[header];


### PR DESCRIPTION
This increases standardization across implementations

Update pinejs-client-core from 8.3.2 to 8.4.0

Change-type: patch